### PR TITLE
Bump version number in homebrew 'url' attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ Please send patches!
 ## How to update
 
 1. Update version number and tarball URL in the `git-friendly.rb`.
-2. Run `wget https://github.com/git-friendly/git-friendly/archive/1.0.5.tar.gz` (with the new version).
-3. Run `shasum -a 256 1.0.5.tar.g` (with the new version).
+2. Run `wget https://github.com/git-friendly/git-friendly/archive/1.0.6.tar.gz` (with the new version).
+3. Run `shasum -a 256 1.0.6.tar.gz` (with the new version).
 4. Copy the checksum to the `git-friendly.rb`.

--- a/git-friendly.rb
+++ b/git-friendly.rb
@@ -7,7 +7,7 @@
 class GitFriendly < Formula
   desc "Streamline your git workflow: `pull`, `branch`, `merge`, `push`"
   homepage "https://github.com/git-friendly/git-friendly"
-  url "https://github.com/git-friendly/git-friendly/archive/1.0.5.tar.gz"
+  url "https://github.com/git-friendly/git-friendly/archive/1.0.6.tar.gz"
   version "1.0.6"
   sha256 "066054f74fcf01bf6968e50914b263ea8640bcd6af76179dac1e1e421afe3206"
 


### PR DESCRIPTION
The recent release didn't bump the version number in enough places, resulting in `brew upgrade git-friendly` failing with an 'Error: SHA256 mismatch', because it's using v1.0.6's checksum against the v1.0.5 archive.